### PR TITLE
Add glob matching. Add tests for glob matching.

### DIFF
--- a/bin/yaml-merge
+++ b/bin/yaml-merge
@@ -2,12 +2,10 @@
 
 'use strict';
 
-const resolve = require('path').resolve;
 const yamlMerge = require('../index.js');
 
 const files = process.argv
   .slice(2)
-  .map((path) => resolve(path));
 const outputFile = yamlMerge(...files);
 
 process.stdout.write(outputFile);

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const readFileSync = require('fs').readFileSync;
 const jsYaml = require('js-yaml');
+const glob = require('glob');
 const _ = require('lodash');
 
 function readAsJSON(fileName) {
@@ -18,7 +19,10 @@ function readAsJSON(fileName) {
  * @return {string} the output YAML file
  */
 function yamlMerge(...from) {
-  const files = from.map((path) => readAsJSON(path));
+  const files = from
+    .reduce((arr, el) => arr.concat(glob.sync(el)), [])
+    .map((path) => readAsJSON(path));
+
   const outputJSON = _.mergeWith({}, ...files, (objValue, srcValue) => {
     if (Array.isArray(objValue) && Array.isArray(srcValue)) {
       return [...objValue, ...srcValue];

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "index.js"
   ],
   "dependencies": {
+    "glob": "^7.1.7",
     "js-yaml": "^4.0.0",
     "lodash": "^4.17.20"
   },

--- a/test/lib-test.js
+++ b/test/lib-test.js
@@ -3,12 +3,17 @@
 'use strict';
 
 const resolve = require('path').resolve;
+const join = require('path').join;
 const expect = require('chai').expect;
 const stripIndent = require('common-tags').stripIndent;
 const merge = require('../index.js');
 
 function fixtureFiles(...names) {
   return names.map((fileName) => resolve(__dirname, './fixtures', fileName));
+}
+
+function globFiles(...globs) {
+  return globs.map((glob) => join(__dirname, './fixtures', glob));
 }
 
 describe('merge logic', function () {
@@ -59,4 +64,33 @@ describe('merge logic', function () {
     ` + '\n'
     );
   });
+});
+
+describe('blog logic', function () {
+  it('merges multiple YAML files', function () {
+    const output = merge(...globFiles('basic/*.yml'));
+
+    expect(output).to.equal(
+      stripIndent`
+      a:
+        foo: bar
+      b:
+        foo: bar
+    ` + '\n'
+    );
+  }),
+    it('merges multiple YAML files (to glob or not to glob)', function () {
+      const output = merge(...globFiles('basic/*.yml', 'merge/a.yml'));
+
+      expect(output).to.equal(
+        stripIndent`
+      a:
+        foo: bar
+      b:
+        foo: bar
+      key:
+        first_value: a
+    ` + '\n'
+      );
+    });
 });


### PR DESCRIPTION
I wanted to use this utility to build pm2 ecosystem files and it worked well. Since my setup generates multiple output yml files (combinations between multiple yml files) it is annoying to have a huge command to build those yml file.

I understand that you might not want to add another dep to the project (since you had lodash i though it would be ok), but i added glob matching to be able to include whole folders etc.

(I believe this is my first PR, so you can tell me  if anything is off )